### PR TITLE
Project local nodejs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: groovy
-
 jdk: oraclejdk7
-
 env:
   global:
   - secure: EHI9YENiyoZEVCbBs+Rch8GuLHNnAJj+8HfyeFBKzktLeenT27QHhpt7yoNcs2p8zfyGvYTJ+p01hV8Fvcogwq+oSYnyMqpR0azmK7eZ6VyzRv7Ei/XaNr7seTTC7RXKWXckslf89U6b3QRS4Dpc4iq4jbaFCZObXikQWFlqy5k=
   - secure: HoxowDZkH3r5aGMX2yjG04f8R2R+vKB3IQRbku8KxvhILhGqnoL6lky1QRFUXhUZD9nvy18cztWjgipbD7BukoaSh2MP71DTea/sTbNK1fHxqKVc8qixJ3IWX4KdNqG0rV5seVZ+zjZ6CnQwawhtIsq3a6s2EzkdfDqM5hqFvlA=
-
-script: "./gradlew ci"
-
+  - secure: UbDRGtGC5HudWlWViu2emSZ4DsrgjVEQ1G7bAn0bbTkImE2SZF34zbNKYFRM66kQZQm16FpH3b6EvQnyWFw2/47a5gezQs8+pg+L5MSwGeqS693n4xu1EsSw+la6+lG/jFem2KnDZ3M1a7hRnC9ie0IxjAVBX6vGxcGzuuax0lc=
+  - secure: KbIiSiENmN1BJwxNv6McUd+lm2sJoH/pq8CAAmkvBn9Gdhcs0OKSPZIWCh5OVdZ3qpnhUL+d/oS71BTgGbUXcjMBWUKn43AtzAnejSUhO/ld66XsUzY+NyNyNuI8qzPdVbqXixSF6//t7YYbIuidgR+C/LFWweEww6hL6t+y5WE=
+script: "./gradlew ci -Pgradle.publish.key=${GRADLE_PUBLISH_KEY} -Pgradle.publish.secret=${GRADLE_PUBLISH_SECRET}"
 sudo: false

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'groovy'
   id 'jacoco'
   id 'java-gradle-plugin'
-  id 'nu.studer.plugindev' version '1.0.3'
+  id 'com.gradle.plugin-publish' version '0.9.0'
   id 'com.jfrog.artifactory' version '3.0.1'
   id 'com.github.kt3k.coveralls' version '2.0.1'
   id 'com.readytalk.ci' version '0.2.3'
@@ -37,19 +37,18 @@ dependencies {
   }
 }
 
-plugindev {
-  pluginImplementationClass 'com.readytalk.gradle.js.JsPlugin'
-  pluginDescription 'Gradle plugin for ReadyTalk-style JavaScript projects.'
-  pluginLicenses 'MIT'
-  pluginTags 'java', 'gradle', 'groovy', 'node', 'javascript'
-  authorId 'dougborg'
-  authorName 'Douglas Borg'
-  authorEmail 'dougborg@dougborg.org'
-  projectUrl = 'http://oss.readytalk.com/gradle-readytalk-js'
-  projectIssuesUrl = 'https://github.com/ReadyTalk/gradle-readytalk-js/issues'
-  projectVcsUrl = 'https://github.com/ReadyTalk/gradle-readytalk-js.git'
-  projectInceptionYear '2014'
-  done() // do not omit this
+pluginBundle {
+  website = 'http://oss.readytalk.com/gradle-readytalk-js'
+  vcsUrl = 'https://github.com/ReadyTalk/gradle-readytalk-js.git'
+  description = 'Gradle plugin for ReadyTalk-style JavaScript projects.'
+
+  plugins {
+    readytalkJsPlugin {
+      id = 'com.readytalk.js'
+      displayName = 'ReadyTalk JS Plugin'
+      tags = [ 'java', 'gradle', 'groovy', 'node', 'javascript' ]
+    }
+  }
 }
 
 jacocoTestReport {
@@ -69,7 +68,7 @@ tasks.coveralls {
 tasks.ci.dependsOn tasks.coveralls
 
 artifactoryPublish.onlyIf { isMaster || isReleaseBranch }
-bintrayUpload.onlyIf { isRelease }
+publishPlugins.onlyIf { isRelease }
 
 artifactory {
   contextUrl = "http://oss.jfrog.org/artifactory"
@@ -81,17 +80,6 @@ artifactory {
       password = bintrayKey
       maven = true
     }
-  }
-}
-
-bintray {
-  user = bintrayUser
-  key = bintrayKey
-  dryRun = !isRelease
-  pkg {
-    userOrg = 'readytalk'
-    repo = 'plugins'
-    version.vcsTag = buildEnv.travisTag
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ if (!isRelease) {
 defaultTasks 'build'
 
 repositories {
+  jcenter()
   maven {
     name 'JFrog OSS snapshot repo'
     url  'https://oss.jfrog.org/oss-snapshot-local/'

--- a/build.gradle
+++ b/build.gradle
@@ -5,12 +5,17 @@ plugins {
   id 'nu.studer.plugindev' version '1.0.3'
   id 'com.jfrog.artifactory' version '3.0.1'
   id 'com.github.kt3k.coveralls' version '2.0.1'
-  id 'com.readytalk.ci' version '0.2.0'
+  id 'com.readytalk.ci' version '0.2.3'
 }
 
 ext {
-  isMaster = buildEnv.travisBranch == "master" && buildEnv.travisPullRequest == 'false'
   isRelease = buildEnv.travisTag ==~ /v\d+\.\d+\.\d+/
+  isMaster = buildEnv.travisBranch == "master" && buildEnv.travisPullRequest == 'false'
+  isReleaseBranch = buildEnv.travisBranch ==~ /release_\d+\.\d+\.\d+/
+}
+
+if (!isRelease) {
+  version = version + '-SNAPSHOT'
 }
 
 defaultTasks 'build'
@@ -20,13 +25,12 @@ repositories {
     name 'JFrog OSS snapshot repo'
     url  'https://oss.jfrog.org/oss-snapshot-local/'
   }
-  jcenter()
 }
 
 dependencies {
   compile gradleApi()
-  compile 'com.moowork.gradle:gradle-node-plugin:0.8'
-  compile 'com.moowork.gradle:gradle-grunt-plugin:0.6'
+  compile 'com.moowork.gradle:gradle-node-plugin:0.9'
+  compile 'com.moowork.gradle:gradle-grunt-plugin:0.9'
 
   testCompile('org.spockframework:spock-core:0.7-groovy-2.0') {
     exclude module: 'groovy-all'
@@ -64,7 +68,7 @@ tasks.coveralls {
 
 tasks.ci.dependsOn tasks.coveralls
 
-artifactoryPublish.onlyIf { isMaster }
+artifactoryPublish.onlyIf { isMaster || isReleaseBranch }
 bintrayUpload.onlyIf { isRelease }
 
 artifactory {
@@ -83,6 +87,7 @@ artifactory {
 bintray {
   user = bintrayUser
   key = bintrayKey
+  dryRun = !isRelease
   pkg {
     userOrg = 'readytalk'
     repo = 'plugins'
@@ -90,4 +95,4 @@ bintray {
   }
 }
 
-wrapper.gradleVersion = '2.2.1'
+wrapper.gradleVersion = '2.3'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.readytalk.gradle
-version=0.2.0-SNAPSHOT
+version=0.2.3
 
 bintrayUser=
 bintrayKey=

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,6 @@ version=0.2.3
 
 bintrayUser=
 bintrayKey=
+
+gradle.publish.key=
+gradle.publish.secret=

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Nov 24 13:26:30 MST 2014
+#Tue Apr 21 11:42:46 MDT 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.3-bin.zip

--- a/src/main/groovy/com/readytalk/gradle/js/JsPlugin.groovy
+++ b/src/main/groovy/com/readytalk/gradle/js/JsPlugin.groovy
@@ -27,6 +27,7 @@ class JsPlugin implements Plugin<Project> {
         version = '0.10.32'
         npmVersion = '2.1.7'
         download = true
+        workDir = project.file("${project.buildDir}/nodejs")
     }
 
     if (project.version == 'unspecified' && project.file('package.json').exists()) {


### PR DESCRIPTION
Take @dansomething's excellent suggestion to make the node installation project-local. This is actually pretty cheap since if the node package has been downloaded before, it is already in the gradle artifact cache.